### PR TITLE
Fix unit tests failing on Windows due to `NamedTemporaryFile` usage

### DIFF
--- a/tests/test_deterministric_metrics.py
+++ b/tests/test_deterministric_metrics.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from tempfile import NamedTemporaryFile
+
 import pytest
 
 from contextcheck import TestScenario
@@ -108,7 +108,6 @@ steps:
 """
 
 
-
 @pytest.mark.parametrize("executor", [config_is_valid_json], indirect=True)
 def test_is_valid_json(executor):
     executor.run_all()
@@ -126,7 +125,7 @@ steps:
     request: '{"name": "John", "age": 30}'
     asserts:
       - kind: has-valid-json-schema
-        assertion: 
+        assertion:
             type: object
             properties:
                 name:
@@ -137,7 +136,7 @@ steps:
                     maximum: 150
             required: ["name", "age"]
       - kind: has-valid-json-schema
-        assertion: 
+        assertion:
             type: object
             properties:
                 name:
@@ -219,10 +218,11 @@ steps:
 """
 
 
-def test_regex_exception():
-    with NamedTemporaryFile("w", suffix=".yaml") as f:
-        f.write(config_regex_2)
-        f.flush()
+def test_regex_exception(tmp_path: Path):
+    temp_file = tmp_path / "test.yaml"
+    temp_file.write_text(config_regex_2)
 
-        with pytest.raises(ValueError, match="Yaml parsing error. It was probably caused by your 'regex' assertion"):
-            TestScenario.from_yaml(Path(f.name))
+    with pytest.raises(
+        ValueError, match="Yaml parsing error. It was probably caused by your 'regex' assertion"
+    ):
+        TestScenario.from_yaml(temp_file)

--- a/tests/test_openai_compatible_endpoint.py
+++ b/tests/test_openai_compatible_endpoint.py
@@ -1,10 +1,10 @@
 from pathlib import Path
-from tempfile import NamedTemporaryFile
+
 import pytest
 
 from contextcheck import TestScenario
-from tests.utils import executor
 from contextcheck.executors.executor import Executor
+from tests.utils import executor
 
 invalid_config = """
 config:
@@ -28,7 +28,7 @@ steps:
    - name: Send hello
      request: 'Say "Hello"'
      asserts:
-        - '"Hello" in response.message'      
+        - '"Hello" in response.message'
 """
 
 openai_config = """
@@ -42,14 +42,13 @@ config:
 """
 
 
-def test_invalid_config():
-    with NamedTemporaryFile("w", suffix=".yaml") as f:
-        f.write(invalid_config)
-        f.flush()
+def test_invalid_config(tmp_path: Path):
+    temp_file = tmp_path / "test.yaml"
+    temp_file.write_text(invalid_config)
 
-        with pytest.raises(ValueError, match="Provider 'Foo' not found"):
-            ts = TestScenario.from_yaml(Path(f.name))
-            Executor(test_scenario=ts)
+    with pytest.raises(ValueError, match="Provider 'Foo' not found"):
+        ts = TestScenario.from_yaml(temp_file)
+        Executor(test_scenario=ts)
 
 
 @pytest.mark.parametrize("executor", [ollama_config], indirect=True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 
 import pytest
 
@@ -8,10 +7,9 @@ from contextcheck.executors.executor import Executor
 
 
 @pytest.fixture
-def executor(request):
-    with NamedTemporaryFile("w", suffix=".yaml") as f:
-        f.write(request.param)
-        f.flush()
+def executor(request, tmp_path: Path):
+    temp_file = tmp_path / "test.yaml"
+    temp_file.write_text(request.param)
 
-        ts = TestScenario.from_yaml(Path(f.name))
-        return Executor(ts)
+    ts = TestScenario.from_yaml(temp_file)
+    return Executor(ts)


### PR DESCRIPTION
### Problem

Unit tests that use `NamedTemporaryFile` are failing on Windows with the following error:
```
PermissionError: [Errno 13] Permission denied: 'C:\Users\User\AppData\Local\Temp\tmpabc123.yaml'
```

This is because on Windows, a file created with `NamedTemporaryFile` cannot be opened again while it's still open. Attempting to read from the file while it's open for writing results in a `PermissionError`.

### Solution
Replace all instances of `NamedTemporaryFile` in the tests with the `tmp_path` fixture provided by pytest. This fixture offers a platform-independent way to create temporary files and directories.

### Testing
On Windows, all unit tests have passed introduced changes in PR.

### Additional Information
  - [Python `tempfile.NamedTemporaryFile` documentation](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile)
  - [pytest `tmp_path` fixture documentation](https://docs.pytest.org/en/stable/how-to/tmp_path.html)

