### PR TITLE
Fix variable scope issue in `eval()` for `AssertionEval`

### DIFF
--- a/tests/test_deterministric_metrics.py
+++ b/tests/test_deterministric_metrics.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from tempfile import NamedTemporaryFile
+
 import pytest
 
 from contextcheck import TestScenario
@@ -108,7 +108,6 @@ steps:
 """
 
 
-
 @pytest.mark.parametrize("executor", [config_is_valid_json], indirect=True)
 def test_is_valid_json(executor):
     executor.run_all()
@@ -126,7 +125,7 @@ steps:
     request: '{"name": "John", "age": 30}'
     asserts:
       - kind: has-valid-json-schema
-        assertion: 
+        assertion:
             type: object
             properties:
                 name:
@@ -137,7 +136,7 @@ steps:
                     maximum: 150
             required: ["name", "age"]
       - kind: has-valid-json-schema
-        assertion: 
+        assertion:
             type: object
             properties:
                 name:
@@ -219,10 +218,11 @@ steps:
 """
 
 
-def test_regex_exception():
-    with NamedTemporaryFile("w", suffix=".yaml") as f:
-        f.write(config_regex_2)
-        f.flush()
+def test_regex_exception(tmp_path: Path):
+    temp_file = tmp_path / "test.yaml"
+    temp_file.write_text(config_regex_2)
 
-        with pytest.raises(ValueError, match="Yaml parsing error. It was probably caused by your 'regex' assertion"):
-            TestScenario.from_yaml(Path(f.name))
+    with pytest.raises(
+        ValueError, match="Yaml parsing error. It was probably caused by your 'regex' assertion"
+    ):
+        TestScenario.from_yaml(temp_file)

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -14,6 +14,7 @@ steps:
       - eval: '"Foo" in response.message'
       - eval: '"bar" in response.message'
       - eval: '"Foo bar foo" == response.message'
+      - eval: 'all(j in response.message for j in ["Foo", "bar", "foo"])'
       - eval: '"fo fo" in response.message'
 """
 
@@ -65,7 +66,8 @@ def test_eval_messages(executor):
     assert executor.test_scenario.steps[0].asserts[0].result is True
     assert executor.test_scenario.steps[0].asserts[1].result is True
     assert executor.test_scenario.steps[0].asserts[2].result is True
-    assert executor.test_scenario.steps[0].asserts[3].result is False
+    assert executor.test_scenario.steps[0].asserts[3].result is True
+    assert executor.test_scenario.steps[0].asserts[4].result is False
 
 
 @pytest.mark.parametrize("executor", [config_eval_stats], indirect=True)

--- a/tests/test_openai_compatible_endpoint.py
+++ b/tests/test_openai_compatible_endpoint.py
@@ -1,10 +1,10 @@
 from pathlib import Path
-from tempfile import NamedTemporaryFile
+
 import pytest
 
 from contextcheck import TestScenario
-from tests.utils import executor
 from contextcheck.executors.executor import Executor
+from tests.utils import executor
 
 invalid_config = """
 config:
@@ -28,7 +28,7 @@ steps:
    - name: Send hello
      request: 'Say "Hello"'
      asserts:
-        - '"Hello" in response.message'      
+        - '"Hello" in response.message'
 """
 
 openai_config = """
@@ -42,14 +42,13 @@ config:
 """
 
 
-def test_invalid_config():
-    with NamedTemporaryFile("w", suffix=".yaml") as f:
-        f.write(invalid_config)
-        f.flush()
+def test_invalid_config(tmp_path: Path):
+    temp_file = tmp_path / "test.yaml"
+    temp_file.write_text(invalid_config)
 
-        with pytest.raises(ValueError, match="Provider 'Foo' not found"):
-            ts = TestScenario.from_yaml(Path(f.name))
-            Executor(test_scenario=ts)
+    with pytest.raises(ValueError, match="Provider 'Foo' not found"):
+        ts = TestScenario.from_yaml(temp_file)
+        Executor(test_scenario=ts)
 
 
 @pytest.mark.parametrize("executor", [ollama_config], indirect=True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 
 import pytest
 
@@ -8,10 +7,9 @@ from contextcheck.executors.executor import Executor
 
 
 @pytest.fixture
-def executor(request):
-    with NamedTemporaryFile("w", suffix=".yaml") as f:
-        f.write(request.param)
-        f.flush()
+def executor(request, tmp_path: Path):
+    temp_file = tmp_path / "test.yaml"
+    temp_file.write_text(request.param)
 
-        ts = TestScenario.from_yaml(Path(f.name))
-        return Executor(ts)
+    ts = TestScenario.from_yaml(temp_file)
+    return Executor(ts)


### PR DESCRIPTION
### Problem

When using the `AssertionEval` class to evaluate expressions that include list comprehensions (e.g., using `all()` or `any()` functions), a `NameError` occurs. This happens because variables like `response` are not accessible within the new local scope created by list comprehensions inside `eval()`.

List comprehensions have their own scope, and variables passed through the `locals` parameter in `eval()` are not accessible within this new scope. This limitation prevents users from writing complex assertions that utilize list comprehensions, reducing the flexibility of the testing framework.

### Solution
To resolve this issue, we need to pass the response object via the `globals` parameter of `eval()` instead of `locals`. This change ensures that response is available in the global scope during evaluation, making it accessible within list comprehensions and other nested scopes inside `eval()`.

### Testing
The following small test case was added in the `tests/test_eval_metrics.py` verifying that it doesn't raise `NameError` when accessing `response`:
```python
config_eval_message = """
steps:
  - name: test eval message
    request: 'Foo bar foo'
    asserts:
      ...
      - eval: 'all(j in response.message for j in ["Foo", "bar", "foo"])'
"""
```
