### PR TITLE
Fix folder option and refactor to Pathlib with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,4 +144,4 @@ Like what we’re building? ⭐ Give it a star to support its development!
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details

--- a/contextcheck/executors/tests_router.py
+++ b/contextcheck/executors/tests_router.py
@@ -1,6 +1,6 @@
-import os
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Literal
 
 from loguru import logger
@@ -15,76 +15,68 @@ from contextcheck.models.models import TestScenario
 
 class TestsRouter(BaseModel):
     output_type: Literal["console", "file"]
-    filename: list[str] | None = []
-    folder: str | None = None
-    output_folder: str | None = None
+    filename: list[Path] | None = []
+    folder: Path | None = None
+    output_folder: Path | None = None
     exit_on_failure: bool = False
     global_test_timestamp: str | None = None
     aggregate_results: bool = False
     show_time_statistics: bool = False
 
+    @model_validator(mode="before")
+    @classmethod
+    def initialize_paths(cls, data: dict) -> dict:
+        if "output_folder" in data and data["output_folder"]:
+            data["output_folder"] = Path(data["output_folder"])
+        if "folder" in data and data["folder"]:
+            data["folder"] = Path(data["folder"])
+        if "filename" in data and data["filename"]:
+            data["filename"] = [Path(file) for file in data["filename"]]
+        return data
+
     @field_validator("filename")
     @classmethod
-    def check_filename(cls, value: list[str]) -> list[str]:
+    def check_filename(cls, value: list[Path] | None) -> list[Path]:
         if value:
-            invalid_files = [file for file in value if not os.path.isfile(file)]
+            invalid_files = [file for file in value if not file.is_file()]
             if invalid_files:
                 raise ValueError(
-                    f'Files {", ".join(invalid_files)} do not exist. Check --filename argument.'
+                    f'Files {", ".join(map(str, invalid_files))} do not exist. Check --filename'
+                    " argument."
                 )
-        return value
+        return value or []
 
     @field_validator("folder")
     @classmethod
-    def check_folder(cls, value: str) -> str:
-        if value and not os.path.isdir(value):
+    def check_folder(cls, value: Path | None) -> Path | None:
+        if value and not value.is_dir():
             raise ValueError(f'Folder "{value}" does not exist. Check --folder argument.')
         return value
 
-    @model_validator(mode="before")
+    @field_validator("output_folder")
     @classmethod
-    def check_files_and_folders(cls, data: dict) -> dict:
-        if data["output_type"] == "file":
-            if not os.path.isdir(data["output_folder"]):
-                os.makedirs(data["output_folder"])
-        return data
+    def ensure_output_folder_exists(cls, value: Path | None) -> Path | None:
+        if value and not value.exists():
+            value.mkdir(parents=True)
+        return value
 
     def model_post_init(self, __context) -> None:
         if not self.global_test_timestamp:
             now = datetime.now(timezone.utc)
             self.global_test_timestamp = str(datetime.timestamp(now))
 
-    def _run_test_scenario(self, filename: str, interface_type: InterfaceBase) -> bool | None:
-        ui = interface_type(test_scenario_filename=filename)  # type: ignore
-        ts = TestScenario.from_yaml(ui.get_scenario_path())
-
-        executor = Executor(ts, ui=ui, exit_on_failure=self.exit_on_failure)
-        scenario_result = executor.run_all()
-        executor.summary(
-            output_folder=self.output_folder,
-            global_test_timestamp=self.global_test_timestamp,
-            aggregate_results=self.aggregate_results,
-            show_time_statistics=self.show_time_statistics,
-        )
-
-        return scenario_result, executor.early_stop
-
     def run_tests(self):
         scenario_results = []
         type_map = {"console": InterfaceTUI, "file": InterfaceOutputFile}
         interface_type = type_map[self.output_type]
 
-        filenames = []
-        if self.filename:
-            for filename in self.filename:
-                filenames.append(filename)
-        elif self.folder:
-            for filename in os.listdir(self.folder):
-                if filename.endswith(".yaml"):
-                    filenames.append(filename)
+        filenames = self.filename or []
+        if self.folder:
+            filenames.extend(self.folder.glob("*.yaml"))
 
         if not filenames:
-            logger.warning("No test scenario to run")
+            logger.warning("No test scenario to run.")
+            return
 
         # TODO: Potential place to increase performance by running several scenarios at once
         for filename in filenames:
@@ -95,3 +87,18 @@ class TestsRouter(BaseModel):
 
         if self.exit_on_failure and not all(scenario_results):
             sys.exit(1)
+
+    def _run_test_scenario(self, filename: Path, interface_type: InterfaceBase) -> bool | None:
+        ui = interface_type(test_scenario_filename=str(filename))  # type: ignore
+        ts = TestScenario.from_yaml(ui.get_scenario_path())
+
+        executor = Executor(ts, ui=ui, exit_on_failure=self.exit_on_failure)
+        scenario_result = executor.run_all()
+        executor.summary(
+            output_folder=str(self.output_folder) if self.output_folder else None,
+            global_test_timestamp=self.global_test_timestamp,
+            aggregate_results=self.aggregate_results,
+            show_time_statistics=self.show_time_statistics,
+        )
+
+        return scenario_result, executor.early_stop

--- a/contextcheck/loaders/yaml.py
+++ b/contextcheck/loaders/yaml.py
@@ -16,16 +16,20 @@ def load_yaml_file(file_path: Path, parse_template: bool = True) -> dict:
         # Get variables from original yaml:
         try:
             yaml_dict_without_template = yaml.safe_load(yaml_content)
-        except yaml.scanner.ScannerError as e: # type: ignore
-            message = ("Yaml parsing error. It was probably caused by your 'regex' assertion " 
-                f"defined with double-quotes.\nUse single quotes or no quotes to fix it.\nError details:\n\n{e}")
+        except yaml.scanner.ScannerError as e:  # type: ignore
+            message = (
+                "Yaml parsing error. It was probably caused by your 'regex' assertion defined with"
+                f" double-quotes.\nUse single quotes or no quotes to fix it.\nError details:\n\n{e}"
+            )
             raise ValueError(message)
-            
-        
+
         variables = yaml_dict_without_template.get("variables", {})
 
         # Some variables text can be multiline, so we need to replace newlines with spaces
-        variables = {key: value.replace("\n", " ") for key, value in variables.items()}
+        variables = {
+            key: value.replace("\n", " ") if isinstance(value, str) else value
+            for key, value in variables.items()
+        }
 
         # Create jinja2 template from original yaml and render it using variables
         template = Template(yaml_content)

--- a/tests/test_tests_router.py
+++ b/tests/test_tests_router.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pytest
+
+from contextcheck.executors.tests_router import TestsRouter
+
+
+def test_initialize_paths(tmp_path):
+    test_file = tmp_path / "test_file.yaml"
+    test_file.write_text("test content")
+    test_folder = tmp_path / "test_folder"
+    test_folder.mkdir()
+
+    data = {
+        "output_type": "file",
+        "output_folder": str(tmp_path),
+        "filename": [str(test_file)],
+        "folder": str(test_folder),
+    }
+    router = TestsRouter(**data)
+
+    assert isinstance(router.output_folder, Path)
+    assert isinstance(router.filename[0], Path)
+    assert isinstance(router.folder, Path)
+    assert router.filename[0] == test_file
+    assert router.folder == test_folder
+
+
+def test_check_filename(tmp_path):
+    valid_file = tmp_path / "valid.yaml"
+    valid_file.write_text("test")
+
+    data = {"output_type": "console", "filename": [str(valid_file)]}
+    router = TestsRouter(**data)
+
+    assert valid_file in router.filename
+
+    # Test with an invalid file
+    with pytest.raises(ValueError, match="do not exist"):
+        TestsRouter(output_type="console", filename=["invalid_file.yaml"])
+
+
+def test_check_folder(tmp_path):
+    data = {"output_type": "console", "folder": str(tmp_path)}
+    router = TestsRouter(**data)
+
+    assert router.folder == tmp_path
+
+    # Test with an invalid folder
+    with pytest.raises(ValueError, match="does not exist"):
+        TestsRouter(output_type="console", folder="invalid_folder")
+
+
+def test_ensure_output_folder_exists(tmp_path):
+    output_folder = tmp_path / "new_output_folder"
+
+    data = {"output_type": "file", "output_folder": str(output_folder)}
+    TestsRouter(**data)
+
+    assert output_folder.exists()
+    assert output_folder.is_dir()


### PR DESCRIPTION
### Problem
The `--folder` option in the `TestsRouter` was not functioning as expected due to issues with handling folder paths and filenames. Additionally, the code relied on `os` module functions, leading to inconsistent path handling and verbosity.

### Solution
1. Refactored the `TestsRouter` class to fully utilize the `Pathlib` library, replacing all `os` module calls.
2. Improved validation logic for `filename`, `folder`, and `output_folder` using `Pathlib` methods like `is_file`, `is_dir`, and `mkdir`.
3. Fixed the issue where `--folder` did not correctly append YAML files using `Path.glob`.

### Testing
- Added comprehensive unit tests using the `tmp_path` fixture to dynamically create files and folders in a cross-platform manner. Updated the test suite to cover:
   - Path initialization.
   - Validation of non-existent files and folders.
   - Ensuring `output_folder` creation when it does not exist.
- Verified that the `--folder` option correctly identifies YAML files and handles missing folders.
- Tested edge cases like empty filenames, invalid paths, and missing output folders.

### Additional Information
Although this PR fixes the functionality of the `--folder` option, the user experience remains suboptimal. Currently, the results table is displayed after each file, making it difficult to follow results when processing multiple files. It would be better to aggregate results and display a single summary table at the end of execution. 

I've created an issue https://github.com/Addepto/contextcheck/issues/5 to track this improvement for better usability